### PR TITLE
docs: Fix a few typos

### DIFF
--- a/aiml/DefaultSubs.py
+++ b/aiml/DefaultSubs.py
@@ -26,7 +26,7 @@ to a Windows-style INI file with the following format:
     he = I
     # and so on...
 
-    # the 'normal' section contains subtitutions run on every input
+    # the 'normal' section contains substitutions run on every input
     # string passed into Kernel.respond().  It's mainly used to
     # correct common misspellings, and to convert contractions
     # ("WHAT'S") into a format that will match an AIML pattern ("WHAT

--- a/aiml/Kernel.py
+++ b/aiml/Kernel.py
@@ -141,7 +141,7 @@ class Kernel:
     def resetBrain(self):
         """Reset the brain to its initial state.
 
-        This is essentially equivilant to:
+        This is essentially equivalent to:
             del(kern)
             kern = aiml.Kernel()
 
@@ -980,7 +980,7 @@ class Kernel:
             recent, and so on.
 
         <that> elements (when they appear inside <template> elements)
-        are the output equivilant of <input> elements; they return one
+        are the output equivalent of <input> elements; they return one
         of the Kernel's previous responses.
 
         """


### PR DESCRIPTION
There are small typos in:
- aiml/DefaultSubs.py
- aiml/Kernel.py

Fixes:
- Should read `substitutions` rather than `subtitutions`.
- Should read `equivalent` rather than `equivilant`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md